### PR TITLE
修復golangci-lint尚未安裝的情況

### DIFF
--- a/make.bash
+++ b/make.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ou pipefail
+set -o pipefail
 
 function help() {
     echo "---- Project: Ptt-backend ----"


### PR DESCRIPTION
## 👏 解決掉的 issue / Resolved Issues
- fix #34 
- fix #35 

## 📝 相關的 issue / Related Issues
- #34 


## ⛏ 變更內容 / Details of Changes
從make.bash移除"set -u" ,   
"-u"會導致bash對variable進行嚴格檢查，variable不存在或沒有被assign過會回傳error

以下指令會出現錯誤
curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$GOBIN" "$GOLANGCI_LINT_VERSION" 

"$GOLANGCI_LINT_VERSION" 未被指定的情況下會拋出unbound variable error,  指令中止

ps:  #35 忘記把local的golangci-lint砍掉再測試此功能

 

