### PR TITLE
Bugfix/fix verbose flag, build command,  remove ./cmd from lint command

### DIFF
--- a/make.bash
+++ b/make.bash
@@ -82,7 +82,7 @@ lint)
     ;;
 # test-unit: Run all unit tests
 test-unit)
-    CGO_ENABLED=1 && go test ./... -v -coverprofile=coverage.out -cover -race
+    CGO_ENABLED=1 && go test ./... -coverprofile=coverage.out -cover -race
     ;;
 # test-integration: Run all integration and unit tests
 test-integration)

--- a/make.bash
+++ b/make.bash
@@ -29,8 +29,8 @@ function build() {
     mkdir -p "bin"
     echo "VERSION: $VERSION"
     echo "GITSHA: $GITSHA"
-    echo "binary file output into ./bin"
-    go build "$GOFLAGS" -ldflags "$LDFLAGS" -o ./bin ./...
+    go build "$GOFLAGS" -ldflags "$LDFLAGS"
+    echo "binary file ./Ptt-backend"
 }
 
 function format() {

--- a/make.bash
+++ b/make.bash
@@ -46,7 +46,7 @@ function lint() {
     fi
     go vet ./...
     echo "golangci-lint checking..."
-    "$GOBIN"/golangci-lint run --deadline=30m --enable=misspell --enable=gosec --enable=gofmt --enable=goimports --enable=golint ./cmd/... ./...
+    "$GOBIN"/golangci-lint run --deadline=30m --enable=misspell --enable=gosec --enable=gofmt --enable=goimports --enable=golint ./...
 }
 # no arguments
 if [ $# -lt 1 ]; then
@@ -87,7 +87,7 @@ test-unit)
 # test-integration: Run all integration and unit tests
 test-integration)
     echo 'mode: atomic' >coverage.out
-    CGO_ENABLED=1 && go test ./... -v -coverprofile=coverage.out -cover -race -tags=integration -covermode=atomic
+    CGO_ENABLED=1 && go test ./...  -coverprofile=coverage.out -cover -race -tags=integration -covermode=atomic
     ;;
 # clean: Remove object files, ./bin, .out files
 clean)

--- a/make.bash
+++ b/make.bash
@@ -89,11 +89,10 @@ test-integration)
     echo 'mode: atomic' >coverage.out
     CGO_ENABLED=1 && go test ./...  -coverprofile=coverage.out -cover -race -tags=integration -covermode=atomic
     ;;
-# clean: Remove object files, ./bin, .out files
+# clean: Remove object files, ./bin, .out .exe files
 clean)
     go clean -i -x
-    echo "rm -rf ./bin *.out"
-    rm -rf ./bin *.out
+    rm -f *.out
     ;;
 *)
     echo "invalid args, please check command"

--- a/make.bat
+++ b/make.bat
@@ -109,11 +109,10 @@ setlocal
 endlocal
 goto end
 
-REM clean: Remove object files, ./bin, .out files
+REM clean: Remove object files, ./bin, .out .exe files
 :clean
 go clean -i -x
-echo delete bin, clean out files
-rmdir /S /Q "bin" 2>nul
+echo delete Ptt-backend.exe, clean out files
 DEL /Q /F /S "*.out" 2>nul
 goto end
 

--- a/make.bat
+++ b/make.bat
@@ -97,14 +97,14 @@ goto end
 REM test-unit: Run all unit tests
 :test-unit
 setlocal
-    set CGO_ENABLED=1 && go test ./... -v -coverprofile=coverage.out -cover -race
+    set CGO_ENABLED=1 && go test ./... -coverprofile=coverage.out -cover -race
 endlocal
 goto end
 
 REM test-integration: Run all integration and unit tests
 :test-integration
 setlocal
-    set CGO_ENABLED=1 && go test ./...  -v -race -tags=integration -covermode=atomic -coverprofile=coverage.tmp
+    set CGO_ENABLED=1 && go test ./... -race -tags=integration -covermode=atomic -coverprofile=coverage.tmp
     DEL "*.tmp"
 endlocal
 goto end

--- a/make.bat
+++ b/make.bat
@@ -65,8 +65,8 @@ set LDFLAGS="-X main/version.version=%VERSION% -X main/version.commit=%GITSHA% -
 mkdir bin 2>nul
 echo VERSION: %VERSION%
 echo GITSHA: %GITSHA%
-echo binary file output into .\bin
-go build %GOFLAGS% -ldflags %LDFLAGS% -o .\bin .\...
+go build %GOFLAGS% -ldflags %LDFLAGS%
+echo executable file .\Ptt-backend.exe
 goto end
 
 REM deps: Ensures fresh go.mod and go.sum for dependencies


### PR DESCRIPTION
## 👏 解決掉的 issue / Resolved Issues


## 📝 相關的 issue / Related Issues
-  #6
- PR #46 
- PR #48 

## ⛏ 變更內容 / Details of Changes
- 修改test-unit, test-integration ，移除  -v flag ，避免t.Log()在github action裡印出錯誤
- 修改lint command，因應main.go的搬動， 移除lint對 ./cmd的檢查
- 修改build command, 依照教學文件 , 將binary輸出至根目錄
- 修改clean command