### PR TITLE
Implement issue #58 [主線] [PTT] 實作個人看板的使用者資訊 (repository)

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -27,7 +27,7 @@ type Repository interface {
 
 	// user.go
 	// GetUsers returns all user reords
-	GetUsers(ctx context.Context) []bbs.UserRecord
+	GetUsers(ctx context.Context) ([]bbs.UserRecord, error)
 	// GetUserFavoriteRecords returns favorite records of a user
 	GetUserFavoriteRecords(ctx context.Context, userID string) ([]bbs.FavoriteRecord, error)
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -47,8 +47,8 @@ func (record *bbsUserRecord) Plan() map[string]interface{} {
 	return map[string]interface{}{}
 }
 
-func (repo *repository) GetUsers(_ context.Context) []bbs.UserRecord {
-	return repo.userRecords
+func (repo *repository) GetUsers(_ context.Context) ([]bbs.UserRecord, error) {
+	return repo.userRecords, nil
 }
 
 func (repo *repository) GetUserFavoriteRecords(ctx context.Context, userID string) ([]bbs.FavoriteRecord, error) {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -7,6 +7,46 @@ import (
 	"github.com/PichuChen/go-bbs"
 )
 
+// BBSUserRecord : currently interface `bbs.UserRecord` of go-bbs
+// lacks some required methods, so we use a mock
+type BBSUserRecord interface {
+	bbs.UserRecord
+	NumBadPosts() int
+	LastCountry() string
+	MailboxDescription() string
+	ChessStatus() map[string]interface{}
+	Plan() map[string]interface{}
+}
+
+type bbsUserRecord struct {
+	bbs.UserRecord
+}
+
+// NumBadPosts returns how many bad posts this user has posted.
+func (record *bbsUserRecord) NumBadPosts() int {
+	return 0
+}
+
+// LastCountry returns last login country of user
+func (record *bbsUserRecord) LastCountry() string {
+	return ""
+}
+
+// MailboxDescription returns the mailbox description of user
+func (record *bbsUserRecord) MailboxDescription() string {
+	return ""
+}
+
+// ChessStatus returns chess status
+func (record *bbsUserRecord) ChessStatus() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+// Plan returns plan
+func (record *bbsUserRecord) Plan() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
 func (repo *repository) GetUsers(_ context.Context) []bbs.UserRecord {
 	return repo.userRecords
 }
@@ -21,5 +61,9 @@ func loadUserRecords(db *bbs.DB) ([]bbs.UserRecord, error) {
 		logger.Errorf("get user rec error: %v", err)
 		return nil, fmt.Errorf("failed to read user records: %w", err)
 	}
-	return userRecords, nil
+	results := make([] bbs.UserRecord, 0, len(userRecords))
+	for _, rec := range userRecords {
+		results = append(results, &bbsUserRecord{rec})
+	}
+	return results, nil
 }

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -14,7 +14,12 @@ func TestGetUsers(t *testing.T) {
 		boardRecords: []bbs.BoardRecord{},
 	}
 
-	actual := repo.GetUsers(context.TODO())
+	actual, err := repo.GetUsers(context.TODO())
+	if err != nil {
+		t.Errorf("GetUsers excepted err == nil, got %v", err)
+		return
+	}
+
 	if actual == nil {
 		t.Errorf("GetUsers got %v, expected not equal nil", actual)
 	}

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -10,7 +10,11 @@ import (
 )
 
 func (usecase *usecase) GetUserByID(ctx context.Context, userID string) (bbs.UserRecord, error) {
-	for _, it := range usecase.repo.GetUsers(ctx) {
+	users, err := usecase.repo.GetUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, it := range users {
 		if userID == it.UserId() {
 			return it, nil
 		}

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/PichuChen/go-bbs"
+	"github.com/Ptt-official-app/Ptt-backend/internal/repository"
 )
 
 func (usecase *usecase) GetUserByID(ctx context.Context, userID string) (bbs.UserRecord, error) {
@@ -28,10 +29,11 @@ func (usecase *usecase) GetUserFavorites(ctx context.Context, userID string) ([]
 }
 
 func (usecase *usecase) GetUserInformation(ctx context.Context, userID string) (map[string]interface{}, error) {
-	user, err := usecase.GetUserByID(ctx, userID)
+	userrec, err := usecase.GetUserByID(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("get userrec for %s failed", userID)
 	}
+	user := userrec.(repository.BBSUserRecord)
 
 	// TODO: Check Etag or Not-Modified for cache
 
@@ -41,14 +43,16 @@ func (usecase *usecase) GetUserInformation(ctx context.Context, userID string) (
 		"realname":             user.RealName(),
 		"number_of_login_days": fmt.Sprintf("%d", user.NumLoginDays()),
 		"number_of_posts":      fmt.Sprintf("%d", user.NumPosts()),
-		// "number_of_badposts":   fmt.Sprintf("%d", user.NumLoginDays),
+		"number_of_badposts":   fmt.Sprintf("%d", user.NumBadPosts()),
 		"money":           fmt.Sprintf("%d", user.Money()),
+		"money_description": getMoneyDiscription(user.Money()),
 		"last_login_time": user.LastLogin().Format(time.RFC3339),
 		"last_login_ipv4": user.LastHost(),
 		"last_login_ip":   user.LastHost(),
-		// "last_login_country": fmt.Sprintf("%d", user.NumLoginDays),
-		"chess_status": map[string]interface{}{},
-		"plan":         map[string]interface{}{},
+		"last_login_country": user.LastCountry(),
+		"mailbox_description": user.MailboxDescription(),
+		"chess_status": user.ChessStatus(),
+		"plan":         user.Plan(),
 	}
 	return result, nil
 }
@@ -81,4 +85,31 @@ func (usecase *usecase) parseFavoriteFolderItem(recs []bbs.FavoriteRecord) []int
 		}
 	}
 	return dataItems
+}
+
+func getMoneyDiscription(money int) string {
+	var result string
+	switch {
+	case money <= 9:
+		result = "債台高築"
+	case money <= 109:
+		result = "赤貧"
+	case money <= 1099:
+		result = "清寒"
+	case money <= 10999:
+		result = "普通"
+	case money <= 109999:
+		result = "小康"
+	case money <= 1099999:
+		result = "小富"
+	case money <= 10999999:
+		result = "中富"
+	case money <= 109999999:
+		result = "大富翁"
+	case money <= 1099999999:
+		result = "富可敵國"
+	default:
+		result = "比爾蓋天"
+	}
+	return result
 }

--- a/internal/usecase/user_mock_test.go
+++ b/internal/usecase/user_mock_test.go
@@ -2,8 +2,9 @@ package usecase
 
 import (
 	"context"
-	"github.com/PichuChen/go-bbs"
 	"time"
+
+	"github.com/PichuChen/go-bbs"
 )
 
 func (repo *MockRepository) GetUsers(ctx context.Context) []bbs.UserRecord {
@@ -31,3 +32,8 @@ func (u *MockUser) NumPosts() int                        { return 0 }
 func (u *MockUser) Money() int                           { return 0 }
 func (u *MockUser) LastLogin() time.Time                 { return time.Unix(0, 0) }
 func (u *MockUser) LastHost() string                     { return "" }
+func (u *MockUser) NumBadPosts() int                     { return 0 }
+func (u *MockUser) LastCountry() string                  { return "" }
+func (u *MockUser) MailboxDescription() string           { return "" }
+func (u *MockUser) ChessStatus() map[string]interface{}  { return map[string]interface{}{} }
+func (u *MockUser) Plan() map[string]interface{}         { return map[string]interface{}{} }

--- a/internal/usecase/user_mock_test.go
+++ b/internal/usecase/user_mock_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/PichuChen/go-bbs"
 )
 
-func (repo *MockRepository) GetUsers(ctx context.Context) []bbs.UserRecord {
+func (repo *MockRepository) GetUsers(ctx context.Context) ([]bbs.UserRecord, error) {
 	ret := []bbs.UserRecord{}
 	ret = append(ret, &MockUser{
 		userId: "pichu",
 	})
-	return ret
+	return ret, nil
 }
 func (repo *MockRepository) GetUserFavoriteRecords(ctx context.Context, userID string) ([]bbs.FavoriteRecord, error) {
 	return []bbs.FavoriteRecord{}, nil


### PR DESCRIPTION
## 👏 解決掉的 issue / Resolved Issues
- close #58

## 📝 相關的 issue / Related Issues
- #主 issue #52
- #子 issue #58

## ⛏ 變更內容 / Details of Changes
- 新增 interface `BBSUserRecord `，用來在 `bbs.UserRecord` 外面包一層 go-bbs 尚未支援的方法，並同步調整 test 相關的 mock，包含:
    - NumBadPosts() int
    - LastCountry() string
    - MailboxDescription() string
    - ChessStatus() map[string]interface{}
    - Plan() map[string]interface{}
- 實作 `getMoneyDiscription()` 以顯示經濟狀況