### PR TITLE
usecase for get popular articles

### DIFF
--- a/internal/delivery/http/route_articles_test.go
+++ b/internal/delivery/http/route_articles_test.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"context"
+
+	"github.com/PichuChen/go-bbs"
+)
+
+func (usecase *MockUsecase) GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error) {
+	return []bbs.ArticleRecord{}, nil
+}

--- a/internal/repository/article.go
+++ b/internal/repository/article.go
@@ -7,5 +7,6 @@ import (
 )
 
 func (repo *repository) GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error) {
+	// TODO: should implement popular articles there
 	return []bbs.ArticleRecord{}, nil
 }

--- a/internal/repository/article.go
+++ b/internal/repository/article.go
@@ -1,0 +1,11 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/PichuChen/go-bbs"
+)
+
+func (repo *repository) GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error) {
+	return []bbs.ArticleRecord{}, nil
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -30,6 +30,10 @@ type Repository interface {
 	GetUsers(ctx context.Context) ([]bbs.UserRecord, error)
 	// GetUserFavoriteRecords returns favorite records of a user
 	GetUserFavoriteRecords(ctx context.Context, userID string) ([]bbs.FavoriteRecord, error)
+
+	// article.go
+	// GetPopularArticles returns all popular articles
+	GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error)
 }
 
 type repository struct {

--- a/internal/usecase/article.go
+++ b/internal/usecase/article.go
@@ -7,8 +7,8 @@ import (
 	"github.com/PichuChen/go-bbs"
 )
 
+// GetPopularArticles returns articles by descending comment_count
 func (usecase *usecase) GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error) {
-	// articles should be sorted
 	articles, err := usecase.repo.GetPopularArticles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GetPopularArticles error: %w", err)

--- a/internal/usecase/article.go
+++ b/internal/usecase/article.go
@@ -1,0 +1,17 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PichuChen/go-bbs"
+)
+
+func (usecase *usecase) GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error) {
+	// articles should be sorted
+	articles, err := usecase.repo.GetPopularArticles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetPopularArticles error: %w", err)
+	}
+	return articles, nil
+}

--- a/internal/usecase/article_mock_test.go
+++ b/internal/usecase/article_mock_test.go
@@ -1,0 +1,29 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/PichuChen/go-bbs"
+)
+
+func (repo *MockRepository) GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error) {
+	ret := []bbs.ArticleRecord{
+		&MockArticle{"Popular Article 1"},
+		&MockArticle{"Popular Article 2"},
+		&MockArticle{"Popular Article 3"},
+	}
+	return ret, nil
+}
+
+type MockArticle struct {
+	title string
+}
+
+func (a *MockArticle) Filename() string    { return "" }
+func (a *MockArticle) Modified() time.Time { return time.Unix(0, 0) }
+func (a *MockArticle) Recommend() int      { return 0 }
+func (a *MockArticle) Date() string        { return "" }
+func (a *MockArticle) Title() string       { return a.title }
+func (a *MockArticle) Money() int          { return 0 }
+func (a *MockArticle) Owner() string       { return "" }

--- a/internal/usecase/article_test.go
+++ b/internal/usecase/article_test.go
@@ -1,0 +1,29 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Ptt-official-app/Ptt-backend/internal/config"
+)
+
+func TestGetPopularArticles(t *testing.T) {
+	resp := &MockRepository{}
+
+	usecase := NewUsecase(&config.Config{}, resp)
+	articles, err := usecase.GetPopularArticles(context.TODO())
+
+	if err != nil {
+		t.Errorf("GetPopularArticles expected err == nil, got %v", err)
+	}
+
+	if len(articles) != 3 {
+		t.Errorf("GetPopularArticles should return 3 articles, got %v", len(articles))
+	}
+
+	expectedFirstArticleTitle := "Popular Article 1"
+	if articles[0].Title() != expectedFirstArticleTitle {
+		t.Errorf("GetPopularArticles should return first article with title %s, got %s", expectedFirstArticleTitle, articles[0].Title())
+	}
+
+}

--- a/internal/usecase/article_test.go
+++ b/internal/usecase/article_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestGetPopularArticles(t *testing.T) {
-	resp := &MockRepository{}
+	repo := &MockRepository{}
 
-	usecase := NewUsecase(&config.Config{}, resp)
+	usecase := NewUsecase(&config.Config{}, repo)
 	articles, err := usecase.GetPopularArticles(context.TODO())
 
 	if err != nil {

--- a/internal/usecase/usecase.go
+++ b/internal/usecase/usecase.go
@@ -42,6 +42,10 @@ type Usecase interface {
 	GetUserIdFromToken(token string) (string, error)
 	// CheckPermission checks permissions
 	CheckPermission(token string, permissionId []Permission, userInfo map[string]string) error // FIXME: use concrete type rather than map[string]string
+
+	// article.go
+	// GetPopularArticles returns all popular articles
+	GetPopularArticles(ctx context.Context) ([]bbs.ArticleRecord, error)
 }
 
 type usecase struct {


### PR DESCRIPTION
<!-- 原則上不接受沒有 Issue ID 的 PR。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決掉的 issue / Resolved Issues
- close #83 

## 📝 相關的 issue / Related Issues
- 支線 #83 
- 主線 #50 

## ⛏ 變更內容 / Details of Changes
<!-- 簡要陳列您的修改 -->
<!-- List down your changes concisely -->
- usecase 新增 article.go, 實作 GetPopularArticles()
- usecase 新增 article_test.go & article_mock_test.go 以測試 usecase.GetPopularArticles()
- repository 新增 article.go，定義 GetPopularArticles()，沒有實作內容

目前相關邏輯是單獨拉到 article.go，並沒有放在 board.go。
主要是覺得可以跟 board 脫鉤，但如果大家覺得沒必要的話可以再移回 board.go