### PR TITLE
add repository function for board post limit information

### DIFF
--- a/internal/repository/board.go
+++ b/internal/repository/board.go
@@ -7,6 +7,35 @@ import (
 	"github.com/PichuChen/go-bbs"
 )
 
+// TODO: go-bbs lacks following interfaces, remove when go-bbs will have implemented functions
+type PostsLimitedBoardRecord interface {
+	PostLimitPosts() uint8
+}
+
+type LoginsLimitedBoardRecord interface {
+	PostLimitLogins() uint8
+}
+
+type BadPostLimitedBoardRecord interface {
+	PostLimitBadPost() uint8
+}
+
+type postsLimitedBoardRecord struct{}
+type loginsLimitedBoardRecord struct{}
+type badPostLimitedBoardRecord struct{}
+
+func (r *postsLimitedBoardRecord) PostLimitPosts() uint8 {
+	return 0
+}
+
+func (r *loginsLimitedBoardRecord) PostLimitLogins() uint8 {
+	return 0
+}
+
+func (r *badPostLimitedBoardRecord) PostLimitBadPost() uint8 {
+	return 0
+}
+
 func (repo *repository) GetBoards(_ context.Context) []bbs.BoardRecord {
 	return repo.boardRecords
 }
@@ -21,6 +50,21 @@ func (repo *repository) GetBoardArticleRecords(_ context.Context, boardID string
 
 func (repo *repository) GetBoardTreasureRecords(_ context.Context, boardID string, treasureIDs []string) ([]bbs.ArticleRecord, error) {
 	return repo.db.ReadBoardTreasureRecordsFile(boardID, treasureIDs)
+}
+
+func (repo *repository) GetBoardPostsLimited(_ context.Context, boardID string) (PostsLimitedBoardRecord, error) {
+	// TODO: replace postsLimitedBoardRecord to real bbs record
+	return &postsLimitedBoardRecord{}, nil
+}
+
+func (repo *repository) GetBoardLoginsLimited(_ context.Context, boardID string) (LoginsLimitedBoardRecord, error) {
+	// TODO: replace loginsLimitedBoardRecord to real bbs record
+	return &loginsLimitedBoardRecord{}, nil
+}
+
+func (repo *repository) GetBoardBadPostLimited(_ context.Context, boardID string) (BadPostLimitedBoardRecord, error) {
+	// TODO: replace badPostLimitedBoardRecord to real bbs record
+	return &badPostLimitedBoardRecord{}, nil
 }
 
 func loadBoardFile(db *bbs.DB) ([]bbs.BoardRecord, error) {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -24,6 +24,15 @@ type Repository interface {
 	GetBoardArticleRecords(ctx context.Context, boardID string) ([]bbs.ArticleRecord, error)
 	// GetBoardTreasureRecords returns treasure article records of a board
 	GetBoardTreasureRecords(ctx context.Context, boardID string, treasureIDs []string) ([]bbs.ArticleRecord, error)
+	// GetBoardPostsLimited returns posts limited record of a board
+	// TODO: replace PostsLimitedBoardRecord with real bbs record
+	GetBoardPostsLimited(ctx context.Context, boardID string) (PostsLimitedBoardRecord, error)
+	// GetBoardLoginsLimited returns logins limited record of a board
+	// TODO: replace LoginsLimitedBoardRecord with real bbs record
+	GetBoardLoginsLimited(ctx context.Context, boardID string) (LoginsLimitedBoardRecord, error)
+	// GetBoardBadPostLimited returns bad posts limited record of a board
+	// TODO: replace BadPostLimitedBoardRecord with real bbs record
+	GetBoardBadPostLimited(ctx context.Context, boardID string) (BadPostLimitedBoardRecord, error)
 
 	// user.go
 	// GetUsers returns all user reords

--- a/internal/usecase/board_mock_test.go
+++ b/internal/usecase/board_mock_test.go
@@ -53,7 +53,7 @@ func (repo *MockRepository) GetPopularArticles(ctx context.Context) ([]repositor
 			date:           "",
 			title:          "Popular Article 1",
 			money:          0,
-			boardID: "Gossiping",
+			boardID:        "Gossiping",
 		},
 		{
 			filename:       "",
@@ -63,7 +63,7 @@ func (repo *MockRepository) GetPopularArticles(ctx context.Context) ([]repositor
 			date:           "",
 			title:          "Popular Article 2",
 			money:          0,
-			boardID: "Gossiping",
+			boardID:        "Gossiping",
 		},
 		{
 			filename:       "",
@@ -73,7 +73,7 @@ func (repo *MockRepository) GetPopularArticles(ctx context.Context) ([]repositor
 			date:           "",
 			title:          "Popular Article 3",
 			money:          0,
-			boardID: "Joke",
+			boardID:        "Joke",
 		},
 	}
 	result := make([]repository.PopularArticleRecord, len(articleRecords))
@@ -85,6 +85,18 @@ func (repo *MockRepository) GetPopularArticles(ctx context.Context) ([]repositor
 
 func (repo *MockRepository) GetBoardTreasureRecords(ctx context.Context, boardID string, treasureIDs []string) ([]bbs.ArticleRecord, error) {
 	return []bbs.ArticleRecord{}, nil
+}
+
+func (repo *MockRepository) GetBoardPostsLimited(ctx context.Context, boardID string) (repository.PostsLimitedBoardRecord, error) {
+	return &MockPostsLimitedBoardRecord{}, nil
+}
+
+func (repo *MockRepository) GetBoardLoginsLimited(ctx context.Context, boardID string) (repository.LoginsLimitedBoardRecord, error) {
+	return &MockLoginsLimitedBoardRecord{}, nil
+}
+
+func (repo *MockRepository) GetBoardBadPostLimited(ctx context.Context, boardID string) (repository.BadPostLimitedBoardRecord, error) {
+	return &MockBadPostLimitedBoardRecord{}, nil
 }
 
 type MockArticleRecord struct {
@@ -124,3 +136,15 @@ func (m MockPopularArticle) Title() string       { return m.title }
 func (m MockPopularArticle) Money() int          { return 0 }
 func (m MockPopularArticle) Owner() string       { return "" }
 func (m MockPopularArticle) BoardID() string     { return m.boardID }
+
+type MockPostsLimitedBoardRecord struct{}
+
+func (m *MockPostsLimitedBoardRecord) PostLimitPosts() uint8 { return 0 }
+
+type MockLoginsLimitedBoardRecord struct{}
+
+func (m *MockLoginsLimitedBoardRecord) PostLimitLogins() uint8 { return 0 }
+
+type MockBadPostLimitedBoardRecord struct{}
+
+func (m *MockBadPostLimitedBoardRecord) PostLimitBadPost() uint8 { return 0 }


### PR DESCRIPTION
## 👏 解決掉的 issue / Resolved Issues
- close #116

## 📝 相關的 issue / Related Issues
- #116
- #63

## ⛏ 變更內容 / Details of Changes
- 參考 [go-bbs的討論](https://github.com/Ptt-official-app/go-bbs/issues/61) 
- 在 repository/board.go 新增以下 mock interfaces: 
  - PostsLimitedBoardRecord
  - LoginsLimitedBoardRecord
  - BadPostLimitedBoardRecord
- repository/repository.go 的 Repository interface 提供以下 method
  - GetBoardPostsLimited()
  - GetBoardLoginsLimited()
  - GetBoardBadPostLimited()