### PR TITLE
Feature/#148 #user preferences usecase and repository

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -41,6 +41,9 @@ type Repository interface {
 	GetUserFavoriteRecords(ctx context.Context, userID string) ([]bbs.FavoriteRecord, error)
 	// GetUserArticles returns user's articles
 	GetUserArticles(ctx context.Context, boardID string) ([]bbs.ArticleRecord, error)
+	// GetUserPreferences returns user's preferences
+	// TODO: replace UserPreferencesRecord with real bbs record
+	GetUserPreferences(ctx context.Context, userID string) (map[string]string, error)
 
 	// article.go
 	// GetPopularArticles returns all popular articles

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -59,6 +59,33 @@ func (repo *repository) GetUserArticles(_ context.Context, boardID string) ([]bb
 	return repo.db.ReadBoardArticleRecordsFile(boardID)
 }
 
+// TODO: mock method for usecase.GetUserPreferences, replace it with real bbs record
+func (repo *repository) GetUserPreferences(_ context.Context, userID string) (map[string]string, error) {
+	result := map[string]string{
+		"favorite_no_highlight":      "No value",
+		"favorite_add_new":           "No value",
+		"friend":                     "No value",
+		"board_sort":                 "No value",
+		"ad_banner":                  "No value",
+		"ad_banner_user_song":        "No value",
+		"dbcs_aware":                 "No value",
+		"dbcs_no_interupting_escape": "No value",
+		"dbcs_drop_repeat":           "No value",
+		"no_modification_mark":       "No value",
+		"colored_modification_mark":  "No value",
+		"default_backup":             "No value",
+		"new_angel_pager":            "No value",
+		"reject_outside_mail":        "No value",
+		"secure_login":               "No value",
+		"foreign":                    "No value",
+		"live_right":                 "No value",
+		"menu_lightbar":              "No value",
+		"cursor_ascii":               "No value",
+		"pager_ui":                   "No value",
+	}
+	return result, nil
+}
+
 func loadUserRecords(db *bbs.DB) ([]bbs.UserRecord, error) {
 	userRecords, err := db.ReadUserRecords()
 	if err != nil {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -59,7 +59,7 @@ func (repo *repository) GetUserArticles(_ context.Context, boardID string) ([]bb
 	return repo.db.ReadBoardArticleRecordsFile(boardID)
 }
 
-// TODO: mock method for usecase.GetUserPreferences, replace it with real bbs record
+// TODO: no required method in go-bbs and we use a mock, replace it when available
 func (repo *repository) GetUserPreferences(_ context.Context, userID string) (map[string]string, error) {
 	result := map[string]string{
 		"favorite_no_highlight":      "No value",

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -96,36 +96,12 @@ func (usecase *usecase) GetUserArticles(ctx context.Context, userID string) ([]i
 }
 
 func (usecase *usecase) GetUserPreferences(ctx context.Context, userID string) (map[string]string, error) {
-	userrec, err := usecase.GetUserByID(ctx, userID)
+	preferencesRec, err := usecase.repo.GetUserPreferences(ctx, userID)
 	if err != nil {
-		return nil, fmt.Errorf("get userrec for %s failed", userID)
+		return nil, fmt.Errorf("get preferences_rec for %s failed", userID)
 	}
-	user := userrec.(repository.BBSUserRecord)
 
-	// TODO: Create a mock repository to pass the values
-	result := map[string]string{
-		"favorite_no_highlight":      user.Nickname(),
-		"favorite_add_new":           "No value",
-		"friend":                     "No value",
-		"board_sort":                 "No value",
-		"ad_banner":                  "No value",
-		"ad_banner_user_song":        "No value",
-		"dbcs_aware":                 "No value",
-		"dbcs_no_interupting_escape": "No value",
-		"dbcs_drop_repeat":           "No value",
-		"no_modification_mark":       "No value",
-		"colored_modification_mark":  "No value",
-		"default_backup":             "No value",
-		"new_angel_pager":            "No value",
-		"reject_outside_mail":        "No value",
-		"secure_login":               "No value",
-		"foreign":                    "No value",
-		"live_right":                 "No value",
-		"menu_lightbar":              "No value",
-		"cursor_ascii":               "No value",
-		"pager_ui":                   "No value",
-	}
-	return result, nil
+	return preferencesRec, nil
 }
 
 func (usecase *usecase) parseFavoriteFolderItem(recs []bbs.FavoriteRecord) []interface{} {

--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -96,12 +96,12 @@ func (usecase *usecase) GetUserArticles(ctx context.Context, userID string) ([]i
 }
 
 func (usecase *usecase) GetUserPreferences(ctx context.Context, userID string) (map[string]string, error) {
-	preferencesRec, err := usecase.repo.GetUserPreferences(ctx, userID)
+	rec, err := usecase.repo.GetUserPreferences(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("get preferences_rec for %s failed", userID)
 	}
 
-	return preferencesRec, nil
+	return rec, nil
 }
 
 func (usecase *usecase) parseFavoriteFolderItem(recs []bbs.FavoriteRecord) []interface{} {

--- a/internal/usecase/user_mock_test.go
+++ b/internal/usecase/user_mock_test.go
@@ -18,6 +18,10 @@ func (repo *MockRepository) GetUserFavoriteRecords(ctx context.Context, userID s
 	return []bbs.FavoriteRecord{}, nil
 }
 
+func (repo *MockRepository) GetUserPreferences(ctx context.Context, userID string) (map[string]string, error) {
+	return map[string]string{"favorite_no_highlight": "YES"}, nil
+}
+
 type MockUser struct {
 	userID string
 }

--- a/internal/usecase/user_mock_test.go
+++ b/internal/usecase/user_mock_test.go
@@ -19,7 +19,7 @@ func (repo *MockRepository) GetUserFavoriteRecords(ctx context.Context, userID s
 }
 
 func (repo *MockRepository) GetUserPreferences(ctx context.Context, userID string) (map[string]string, error) {
-	return map[string]string{"favorite_no_highlight": "YES"}, nil
+	return map[string]string{"favorite_no_highlight": "true"}, nil
 }
 
 type MockUser struct {


### PR DESCRIPTION


## 👏 解決掉的 issue / Resolved Issues
- close #148 


## 📝 相關的 issue / Related Issues
- #62 

## ⛏ 變更內容 / Details of Changes
- 在repository新增mock的GetUserPreferences: 修改的檔案有internal/repository/repository.go 及internal/repository/user.go
- 修改internal/usecase/user.go內的GetUserPreferences: 直接呼叫repository的GetUserPreferences
- 在internal/usecase/user_mock_test.go為MockRepository新增GetUserPreferences