### PR TITLE
Implement get user info usecase

### DIFF
--- a/internal/usecase/user.go
+++ b/internal/usecase/user.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/Ptt-official-app/Ptt-backend/internal/repository"
@@ -45,10 +46,10 @@ func (usecase *usecase) GetUserInformation(ctx context.Context, userID string) (
 		"user_id":              user.UserID(),
 		"nickname":             user.Nickname(),
 		"realname":             user.RealName(),
-		"number_of_login_days": fmt.Sprintf("%d", user.NumLoginDays()),
-		"number_of_posts":      fmt.Sprintf("%d", user.NumPosts()),
-		"number_of_badposts":   fmt.Sprintf("%d", user.NumBadPosts()),
-		"money":                fmt.Sprintf("%d", user.Money()),
+		"number_of_login_days": strconv.FormatInt(int64(user.NumLoginDays()), 10),
+		"number_of_posts":      strconv.FormatInt(int64(user.NumPosts()), 10),
+		"number_of_badposts":   strconv.FormatInt(int64(user.NumBadPosts()), 10),
+		"money":                strconv.FormatInt(int64(user.Money()), 10),
 		"money_description":    getMoneyDiscription(user.Money()),
 		"last_login_time":      user.LastLogin().Format(time.RFC3339),
 		"last_login_ipv4":      user.LastHost(),

--- a/internal/usecase/user_test.go
+++ b/internal/usecase/user_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Ptt-official-app/Ptt-backend/internal/config"
@@ -35,6 +36,42 @@ func TestGetUserByID(t *testing.T) {
 		return
 	}
 
+}
+
+func TestGetUserInformation_InputNotExistUser_ReturnError(t *testing.T) {
+	userID := "not-exist-user-id"
+	errMsg := fmt.Sprintf("get userrec for %s failed", userID)
+	repo := &MockRepository{}
+	usecase := NewUsecase(&config.Config{}, repo)
+
+	data, err := usecase.GetUserInformation(context.TODO(), userID)
+	// TODO: check return error message with error object
+	if err.Error() != errMsg {
+		t.Errorf("GetUserInformation with %s expected error, got %v", userID, err)
+	}
+
+	if data != nil {
+		t.Errorf("GetUserInformation with %s expect nil data, got %v", userID, data)
+	}
+}
+
+func TestGetUserInformation_InputPichu_ReturnData(t *testing.T) {
+	userID := "pichu"
+	repo := &MockRepository{}
+	usecase := NewUsecase(&config.Config{}, repo)
+
+	data, err := usecase.GetUserInformation(context.TODO(), userID)
+	if err != nil {
+		t.Errorf("GetUserInformation with %s expected nil, got %v", userID, err)
+	}
+
+	if data == nil {
+		t.Errorf("GetUserInformation with %s expected data, got nil", userID)
+	}
+
+	if data["user_id"] != userID {
+		t.Errorf("GetUserInformation with %s expect %s, got %s", userID, userID, data["user_id"])
+	}
 }
 
 func TestGetUserArticles(t *testing.T) {


### PR DESCRIPTION
<!-- 原則上不接受沒有 Issue ID 的 PR。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決掉的 issue / Resolved Issues
- close #165 

## 📝 相關的 issue / Related Issues
- #52 

## ⛏ 變更內容 / Details of Changes
<!-- 簡要陳列您的修改 -->
<!-- List down your changes concisely -->
- usecase
  - 修改 `GetUserInformation()` 用`strconv.FormatInt()` 取代 `fmt.Sprintf()` 以改善效率
  - 新增 UserInformation test case
    - 測試傳入 not exist user 回傳 error
    - 測試傳入正確 user ID 回傳資料