### PR TITLE
feat: Implement mailgun provider 

### DIFF
--- a/internal/mail/mail.go
+++ b/internal/mail/mail.go
@@ -16,6 +16,9 @@ func NewMailProvider(mailDriver string) (Mail, error) {
 	case "smtp":
 		provider := newSMTPProvider(urlStruct)
 		return provider, nil
+
+	case "mailgun":
+		return newMailgunProvider(urlStruct), nil
 	}
 
 	return &mail{}, nil

--- a/internal/mail/mail_test.go
+++ b/internal/mail/mail_test.go
@@ -1,0 +1,32 @@
+package mail
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewMailProvider_WithSMTP(t *testing.T) {
+	provider, err := NewMailProvider("smtp://username@mail.smtp.com:587")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+
+	providerType := reflect.TypeOf(provider).String()
+	expectType := reflect.TypeOf(&smtpProvider{}).String()
+	if providerType != expectType {
+		t.Errorf("expect %s, got %s", expectType, providerType)
+	}
+}
+
+func TestNewMailProvider_WithMailgun(t *testing.T) {
+	provider, err := NewMailProvider("mailgun://host?api_key=xxx&domain=yyy")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+
+	providerType := reflect.TypeOf(provider).String()
+	expectType := reflect.TypeOf(&mailgunProvider{}).String()
+	if providerType != expectType {
+		t.Errorf("expect %s, got %s", expectType, providerType)
+	}
+}

--- a/internal/mail/mailgun.go
+++ b/internal/mail/mailgun.go
@@ -16,8 +16,7 @@ const (
 )
 
 var (
-	_         Mail = &mailgunProvider{}
-	goodCodes      = []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}
+	_ Mail = &mailgunProvider{}
 )
 
 type mailgunProvider struct {
@@ -66,7 +65,7 @@ func (m *mailgunProvider) Send(from, to, title string, body []byte) error {
 		return err
 	}
 
-	if notGood(resp.StatusCode) {
+	if resp.StatusCode != http.StatusOK {
 		bodyData, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
@@ -75,13 +74,4 @@ func (m *mailgunProvider) Send(from, to, title string, body []byte) error {
 	}
 
 	return nil
-}
-
-func notGood(statusCode int) bool {
-	for _, i := range goodCodes {
-		if statusCode == i {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/mail/mailgun.go
+++ b/internal/mail/mailgun.go
@@ -1,0 +1,87 @@
+package mail
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+const (
+	scheme     = "https"
+	apiVersion = "v3"
+	endpoint   = "messages"
+)
+
+var (
+	_         Mail = &mailgunProvider{}
+	goodCodes      = []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}
+)
+
+type mailgunProvider struct {
+	domain  string
+	apiKey  string
+	hostURL *url.URL
+	client  *http.Client
+}
+
+func newMailgunProvider(u *url.URL) *mailgunProvider {
+	query := u.Query()
+	domain := query.Get("domain")
+	apiKey := query.Get("api_key")
+
+	hostURL := &url.URL{
+		Scheme: scheme,
+		Host:   u.Host,
+		Path:   path.Join(apiVersion, domain, endpoint),
+	}
+
+	return &mailgunProvider{
+		domain:  domain,
+		apiKey:  apiKey,
+		hostURL: hostURL,
+		client:  http.DefaultClient,
+	}
+}
+
+func (m *mailgunProvider) Send(from, to, title string, body []byte) error {
+	formData := url.Values{}
+
+	formData.Add("from", from)
+	formData.Add("to", to)
+	formData.Add("subject", title)
+	formData.Add("text", string(body))
+
+	req, err := http.NewRequest(http.MethodPost, m.hostURL.String(), strings.NewReader(formData.Encode()))
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth("api", m.apiKey)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if notGood(resp.StatusCode) {
+		bodyData, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("response status: %s, body: %s", resp.Status, string(bodyData))
+	}
+
+	return nil
+}
+
+func notGood(statusCode int) bool {
+	for _, i := range goodCodes {
+		if statusCode == i {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mail/mailgun_test.go
+++ b/internal/mail/mailgun_test.go
@@ -1,0 +1,98 @@
+package mail
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"testing"
+)
+
+const (
+	testApiKey = "key"
+	testDomain = "pttapp.cc"
+)
+
+var (
+	testQuery = url.Values{"api_key": {testApiKey}, "domain": {testDomain}}
+)
+
+func TestMailgunSend_ReturnNoError(t *testing.T) {
+	expectPath := path.Join("/", apiVersion, testDomain, endpoint)
+	testFrom := "test@example.com"
+	testTo := "test"
+	testTitle := "test"
+	testText := []byte("test")
+
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != expectPath {
+			http.Error(w, "URL path is invalid.", http.StatusBadRequest)
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "Request method must be POST", http.StatusBadRequest)
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			fmt.Fprintf(w, "ParseForm() err: %v", err)
+			return
+		}
+
+		if reqFrom := r.FormValue("from"); reqFrom != testFrom {
+			http.Error(w, fmt.Sprintf(`FormValue("from"): %q does not match %q`, reqFrom, testFrom), http.StatusBadRequest)
+			return
+		}
+		if reqTo := r.FormValue("to"); reqTo != testTo {
+			http.Error(w, fmt.Sprintf(`FormValue("to"): %q does not match %q`, reqTo, testTo), http.StatusBadRequest)
+			return
+		}
+		if reqTitle := r.FormValue("subject"); reqTitle != testTitle {
+			http.Error(w, fmt.Sprintf(`FormValue("subject"): %q does not match %q`, reqTitle, testTitle), http.StatusBadRequest)
+			return
+		}
+		if reqText := r.FormValue("text"); reqText != string(testText) {
+			http.Error(w, fmt.Sprintf(`FormValue("text"): %q does not match %q`, reqText, string(testText)), http.StatusBadRequest)
+			return
+		}
+
+	}))
+	defer testServer.Close()
+
+	u, err := url.Parse(testServer.URL)
+	if err != nil {
+		t.Errorf("parse URL error: %v", err)
+		return
+	}
+	u.RawQuery = testQuery.Encode()
+
+	mp := newMailgunProvider(u)
+	mp.client = testServer.Client()
+	err = mp.Send(testFrom, testTo, testTitle, testText)
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+}
+
+func TestMailgunSend_ReturnError(t *testing.T) {
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
+		return
+	}))
+	defer testServer.Close()
+
+	u, err := url.Parse(testServer.URL)
+	if err != nil {
+		t.Errorf("parse URL error: %v", err)
+		return
+	}
+	u.RawQuery = testQuery.Encode()
+
+	mp := newMailgunProvider(u)
+	mp.client = testServer.Client()
+	err = mp.Send("test", "test", "test", []byte("test"))
+	if err == nil {
+		t.Errorf("expect error, got %v", err)
+	}
+}

--- a/internal/mail/mailgun_test.go
+++ b/internal/mail/mailgun_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	testApiKey = "key"
+	testAPIKey = "key"
 	testDomain = "pttapp.cc"
 )
 
 var (
-	testQuery = url.Values{"api_key": {testApiKey}, "domain": {testDomain}}
+	testQuery = url.Values{"api_key": {testAPIKey}, "domain": {testDomain}}
 )
 
 func TestMailgunSend_ReturnNoError(t *testing.T) {
@@ -78,7 +78,6 @@ func TestMailgunSend_ReturnNoError(t *testing.T) {
 func TestMailgunSend_ReturnError(t *testing.T) {
 	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
-		return
 	}))
 	defer testServer.Close()
 


### PR DESCRIPTION
<!-- 原則上不接受沒有 Issue ID 的 PR。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決掉的 issue / Resolved Issues
- close #197 

## 📝 相關的 issue / Related Issues
- #191 

## ⛏ 變更內容 / Details of Changes
<!-- 簡要陳列您的修改 -->
<!-- List down your changes concisely -->
- `mail.go` - 新增 case 呼叫新增 mailgun provider
- `mail_test.go` - 新增兩個測試關於 `NewMailProvider()`
- `mailgun.go` - mailgun provider 實作
- `mailgun_test.go` - 測試 mailgun provider

## 其他
關於 mailgun provider test，我是用自己起一個 https server 的作法去測，這樣 Send 成功以及失敗就都可以被測到。
測試成功的部份有在 handler function 裡面對 request 做一些檢查，如果覺得這個部分不需要，其實也可以拿掉。
另外我新增了 `mail_test.go` 的想法是覺得 `NewMailProvider()` 裡面的邏輯 應該是要在這個 test file 裡面驗證。