### PR TITLE
add route for update usefulness

### DIFF
--- a/internal/delivery/http/route_append_comment.go
+++ b/internal/delivery/http/route_append_comment.go
@@ -16,7 +16,12 @@ func (delivery *Delivery) appendComment(w http.ResponseWriter, r *http.Request, 
 
 	appendType := r.PostFormValue("type")
 	text := r.PostFormValue("text")
-	if appendType == "" || text == "" {
+
+	updateUsefulness := false
+	if appendType == "↑" || appendType == "↓" {
+		updateUsefulness = true
+	}
+	if appendType == "" || (!updateUsefulness && text == "") {
 		w.WriteHeader(500)
 		return
 	}
@@ -42,14 +47,25 @@ func (delivery *Delivery) appendComment(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	res, err := delivery.usecase.AppendComment(
-		ctx,
-		userID,
-		boardID,
-		filename,
-		appendType,
-		text,
-	)
+	var res repository.PushRecord
+	if updateUsefulness {
+		res, err = delivery.usecase.UpdateUsefulness(
+			ctx,
+			userID,
+			boardID,
+			filename,
+			appendType,
+		)
+	} else {
+		res, err = delivery.usecase.AppendComment(
+			ctx,
+			userID,
+			boardID,
+			filename,
+			appendType,
+			text,
+		)
+	}
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/internal/delivery/http/route_append_comment_test.go
+++ b/internal/delivery/http/route_append_comment_test.go
@@ -65,3 +65,33 @@ func TestAppendCommentResponse(t *testing.T) {
 			status, http.StatusOK)
 	}
 }
+
+func TestAppendCommentWithUsefulnessResponse(t *testing.T) {
+	userID := "id"
+	usecase := NewMockUsecase()
+	delivery := NewHTTPDelivery(usecase)
+
+	v := url.Values{}
+	v.Set("action", "append_comment")
+	v.Set("type", "↑")
+	t.Logf("testing body: %v", v)
+	req, err := http.NewRequest("POST", "/v1/boards/test/articles/test", strings.NewReader(v.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token := usecase.CreateAccessTokenWithUsername(userID)
+	t.Logf("testing token: %v", token)
+	req.Header.Add("Authorization", "bearer "+token)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	r := http.NewServeMux()
+	r.HandleFunc("/v1/boards/", delivery.routeBoards)
+	r.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+}

--- a/internal/delivery/http/route_articles_test.go
+++ b/internal/delivery/http/route_articles_test.go
@@ -27,3 +27,7 @@ func (usecase *MockUsecase) ForwardArticleToEmail(ctx context.Context, userID, b
 func (usecase *MockUsecase) CreateArticle(ctx context.Context, userID, boardID, title, article string) (bbs.ArticleRecord, error) {
 	return nil, nil
 }
+
+func (usecase *MockUsecase) UpdateUsefulness(ctx context.Context, userID, boardID, filename, appendType string) (repository.PushRecord, error) {
+	return nil, nil
+}

--- a/internal/usecase/article.go
+++ b/internal/usecase/article.go
@@ -18,6 +18,10 @@ func (usecase *usecase) GetPopularArticles(ctx context.Context) ([]repository.Po
 	return articles, nil
 }
 
+func (usecase *usecase) UpdateUsefulness(ctx context.Context, userID, boardID, filename, appendType string) (repository.PushRecord, error) {
+	return nil, nil
+}
+
 // AppendComment append comment to specific article
 func (usecase *usecase) AppendComment(ctx context.Context, userID, boardID, filename, appendType, text string) (repository.PushRecord, error) {
 	result, err := usecase.repo.AppendComment(ctx, userID, boardID, filename, appendType, text)

--- a/internal/usecase/usecase.go
+++ b/internal/usecase/usecase.go
@@ -66,6 +66,8 @@ type Usecase interface {
 	ForwardArticleToBoard(ctx context.Context, userID, boardID, filename, boardName string) (repository.ForwardArticleToBoardRecord, error)
 	// ForwardArticleToEmail returns forwarding to email results
 	ForwardArticleToEmail(ctx context.Context, userID, boardID, filename, email string) error
+	// UpdateUsefulness update article usefulness
+	UpdateUsefulness(ctx context.Context, userID, boardID, filename, appendType string) (repository.PushRecord, error)
 
 	// mail.go
 	UpdateMail(mail mail.Mail) error


### PR DESCRIPTION
## 👏 解決掉的 issue / Resolved Issues
- close #230 

## 📝 相關的 issue / Related Issues
- #230 
- #210 

## ⛏ 變更內容 / Details of Changes
- 因為 API endpoint 仍使用文章推文，所以沒有新增 route，而是使用原本的 `delivery.appendComment`
- 如果 type 是 `↑` 或 `↓`，則 text 可以為空
- 如果是上下箭頭推文則呼叫 `usecase.UpdateUsefulness`


目前程式直接判斷 `appendType == "↑"`，有需改成用 unicode 表示嗎？像是 `appendType == "\u2191"`