### PR TITLE
fix article-forward router

### DIFF
--- a/internal/delivery/http/errors.go
+++ b/internal/delivery/http/errors.go
@@ -107,7 +107,27 @@ func TokenPermissionError(r *http.Request, err error) []byte {
 func NewNoPermissionForCreateBoardArticlesError(r *http.Request, boardID string) []byte {
 	m := map[string]string{
 		"error":             "no_permission_for_create_board_articles",
-		"error_description": "user don't have permission for create board article" + boardID,
+		"error_description": "user don't have permission for creating an article in board " + boardID,
+	}
+
+	b, _ := json.MarshalIndent(m, "", "  ")
+	return b
+}
+
+func NewNoPermissionForForwardArticleError(r *http.Request, filename string) []byte {
+	m := map[string]string{
+		"error":             "no_permission_for_forward_board_article",
+		"error_description": "user don't have permission for forward board article " + filename,
+	}
+
+	b, _ := json.MarshalIndent(m, "", "  ")
+	return b
+}
+
+func NewNoPermissionForForwardArticleToEmailError(r *http.Request, filename, email string) []byte {
+	m := map[string]string{
+		"error":             "no_permission_for_forward_board_article_to_email",
+		"error_description": "user don't have permission for forward board article " + filename + " to email " + email,
 	}
 
 	b, _ := json.MarshalIndent(m, "", "  ")

--- a/internal/delivery/http/errors.go
+++ b/internal/delivery/http/errors.go
@@ -107,7 +107,7 @@ func TokenPermissionError(r *http.Request, err error) []byte {
 func NewNoPermissionForCreateBoardArticlesError(r *http.Request, boardID string) []byte {
 	m := map[string]string{
 		"error":             "no_permission_for_create_board_articles",
-		"error_description": "user don't have permission for creating an article in board " + boardID,
+		"error_description": "user don't have permission to create an article in board " + boardID,
 	}
 
 	b, _ := json.MarshalIndent(m, "", "  ")
@@ -117,7 +117,7 @@ func NewNoPermissionForCreateBoardArticlesError(r *http.Request, boardID string)
 func NewNoPermissionForForwardArticleError(r *http.Request, filename string) []byte {
 	m := map[string]string{
 		"error":             "no_permission_for_forward_board_article",
-		"error_description": "user don't have permission for forward board article " + filename,
+		"error_description": "user don't have permission to forward article " + filename,
 	}
 
 	b, _ := json.MarshalIndent(m, "", "  ")
@@ -127,7 +127,7 @@ func NewNoPermissionForForwardArticleError(r *http.Request, filename string) []b
 func NewNoPermissionForForwardArticleToEmailError(r *http.Request, filename, email string) []byte {
 	m := map[string]string{
 		"error":             "no_permission_for_forward_board_article_to_email",
-		"error_description": "user don't have permission for forward board article " + filename + " to email " + email,
+		"error_description": "user don't have permission to forward article " + filename + " to email " + email,
 	}
 
 	b, _ := json.MarshalIndent(m, "", "  ")

--- a/internal/delivery/http/route.go
+++ b/internal/delivery/http/route.go
@@ -183,6 +183,7 @@ func (delivery *Delivery) postBoards(w http.ResponseWriter, r *http.Request) {
 			return
 		} else if action == "forward_article" && filename != "" {
 			delivery.forwardArticle(w, r, boardID, filename)
+			return
 		} else if action == "add_article" {
 			delivery.publishPost(w, r, boardID)
 			return

--- a/internal/delivery/http/route_forward_article.go
+++ b/internal/delivery/http/route_forward_article.go
@@ -65,11 +65,11 @@ func (delivery *Delivery) forwardArticle(w http.ResponseWriter, r *http.Request,
 		)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
+			delivery.logger.Noticef("user %s forward file %s from board %s to board %s failed with error %s", userID, filename, boardID, toBoard, err.Error())
 			_, err := w.Write(NewNoPermissionForCreateBoardArticlesError(r, toBoard))
 			if err != nil {
 				delivery.logger.Errorf("write NoPermissionForCreateBoardArticlesError error: %w", err)
 			}
-			delivery.logger.Noticef("user %s forward file %s from board %s to board %s failed with error %s", userID, filename, boardID, toBoard, err.Error())
 			return
 		}
 	}
@@ -98,11 +98,11 @@ func (delivery *Delivery) forwardArticle(w http.ResponseWriter, r *http.Request,
 		)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
+			delivery.logger.Noticef("user %s forward file %s from board %s to email %s failed with error %s", userID, filename, toEmail, toBoard, err.Error())
 			_, err := w.Write(NewNoPermissionForForwardArticleToEmailError(r, filename, toEmail))
 			if err != nil {
 				delivery.logger.Errorf("write NoPermissionForForwardArticleToEmailError error: %w", err)
 			}
-			delivery.logger.Noticef("user %s forward file %s from board %s to email %s failed with error %s", userID, filename, toEmail, toBoard, err.Error())
 			return
 		}
 	}

--- a/internal/delivery/http/route_forward_article_test.go
+++ b/internal/delivery/http/route_forward_article_test.go
@@ -324,7 +324,10 @@ func TestForwardArticleFunction(t *testing.T) {
 		"error":             "no_permission_for_create_board_articles",
 		"error_description": "user don't have permission to create an article in board " + toBoardID,
 	}
-	decoder.Decode(&actual)
+	err = decoder.Decode(&actual)
+	if err != nil {
+		t.Fatalf("decode response body failed: %s", err.Error())
+	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected %s, but got %s", expected, actual)
 	}
@@ -349,7 +352,10 @@ func TestForwardArticleFunction(t *testing.T) {
 		"error":             "no_permission_for_forward_board_article_to_email",
 		"error_description": "user don't have permission to forward article random-filename to email " + email,
 	}
-	decoder.Decode(&actual)
+	err = decoder.Decode(&actual)
+	if err != nil {
+		t.Fatalf("decode response body failed: %s", err.Error())
+	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected %s, but got %s", expected, actual)
 	}
@@ -372,7 +378,10 @@ func TestForwardArticleFunction(t *testing.T) {
 		"error":             "no_permission_for_create_board_articles",
 		"error_description": "user don't have permission to create an article in board " + toBoardID,
 	}
-	decoder.Decode(&actual)
+	err = decoder.Decode(&actual)
+	if err != nil {
+		t.Fatalf("decode response body failed: %s", err.Error())
+	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected %s, but got %s", expected, actual)
 	}
@@ -397,7 +406,10 @@ func TestForwardArticleFunction(t *testing.T) {
 		"error":             "no_permission_for_forward_board_article_to_email",
 		"error_description": "user don't have permission to forward article random-filename to email " + email,
 	}
-	decoder.Decode(&actual)
+	err = decoder.Decode(&actual)
+	if err != nil {
+		t.Fatalf("decode response body failed: %s", err.Error())
+	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected %s, but got %s", expected, actual)
 	}

--- a/internal/delivery/http/route_forward_article_test.go
+++ b/internal/delivery/http/route_forward_article_test.go
@@ -148,7 +148,7 @@ func (mockUsecase *MockForwardArticleToBoardUseCase) ForwardArticleToEmail(ctx c
 	return nil
 }
 
-func (usecase *MockForwardArticleToBoardUseCase) GetUserIDFromToken(token string) (string, error) {
+func (mockUsecase *MockForwardArticleToBoardUseCase) GetUserIDFromToken(token string) (string, error) {
 	if token == "" {
 		return "", errors.New("token not found")
 	}

--- a/internal/delivery/http/route_forward_article_test.go
+++ b/internal/delivery/http/route_forward_article_test.go
@@ -1,11 +1,19 @@
 package http
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/Ptt-official-app/Ptt-backend/internal/repository"
+	UseCase "github.com/Ptt-official-app/Ptt-backend/internal/usecase"
 )
 
 // TestForwardArticleBadRequest test request post `/v1/boards/{}/articles/{}` post
@@ -44,7 +52,7 @@ func TestForwardArticleInternalServerError(t *testing.T) {
 
 	v := url.Values{}
 	v.Set("action", "forward_article")
-	v.Set("board", "")
+	v.Set("board_id", "")
 	v.Set("email", "")
 	t.Logf("testing body: %v", v)
 	req, err := http.NewRequest("POST", "/v1/boards/test/articles/test", strings.NewReader(v.Encode()))
@@ -62,9 +70,9 @@ func TestForwardArticleInternalServerError(t *testing.T) {
 	r.HandleFunc("/v1/boards/", delivery.routeBoards)
 	r.ServeHTTP(rr, req)
 
-	if status := rr.Code; status != 500 {
+	if status := rr.Code; status != http.StatusBadRequest {
 		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, 500)
+			status, http.StatusBadRequest)
 	}
 }
 
@@ -75,7 +83,7 @@ func TestForwardArticleResponse(t *testing.T) {
 
 	v := url.Values{}
 	v.Set("action", "forward_article")
-	v.Set("board", "SYSOP")
+	v.Set("board_id", "SYSOP")
 	v.Set("email", "pichu@tih.tw")
 	t.Logf("testing body: %v", v)
 	req, err := http.NewRequest("POST", "/v1/boards/test/articles/test", strings.NewReader(v.Encode()))
@@ -96,5 +104,182 @@ func TestForwardArticleResponse(t *testing.T) {
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
+	}
+}
+
+type MockForwardArticleToBoardUseCase struct {
+	MockUsecase
+	token                     string
+	checkPermissionParameters func(permission UseCase.Permission, permissionParameters map[string]string)
+	forwardArticleToBoard     func(userID, boardID, filename, toBoard string) error
+	forwardArticleToEmail     func(userID, boardID, filename, email string) error
+}
+
+func (usecase *MockForwardArticleToBoardUseCase) CheckPermission(token string, permissionList []UseCase.Permission, params map[string]string) error {
+	for _, permission := range permissionList {
+		switch permission {
+		case UseCase.PermissionForwardArticleToBoard:
+			fallthrough
+		case UseCase.PermissionForwardArticleToEmail:
+			usecase.checkPermissionParameters(permission, params)
+			if usecase.token != token {
+				return errors.New("token not match")
+			}
+		default:
+			return errors.New("unexpected permission check: " + string(permission))
+		}
+	}
+	return nil
+}
+
+func (usecase *MockForwardArticleToBoardUseCase) ForwardArticleToBoard(ctx context.Context, userID, boardID, filename, boardName string) (repository.ForwardArticleToBoardRecord, error) {
+	return nil, usecase.forwardArticleToBoard(userID, boardID, filename, boardName)
+}
+
+func (usecase *MockForwardArticleToBoardUseCase) ForwardArticleToEmail(ctx context.Context, userID, boardID, filename, email string) error {
+	return usecase.forwardArticleToEmail(userID, boardID, filename, email)
+}
+
+func TestForwardArticleFunction(t *testing.T) {
+	usecase := &MockForwardArticleToBoardUseCase{}
+	delivery := NewHTTPDelivery(usecase)
+	boardID := "test"
+	toBoardID := "target"
+	email := "example@example.com"
+	filename := "random-filename"
+	userData, err := usecase.GetUserByID(context.Background(), "id")
+	if err != nil {
+		t.Fatalf("get error \"%s\" when create mock user %s", err.Error(), "id")
+	}
+	token := usecase.CreateAccessTokenWithUsername(userData.UserID())
+
+	// check token error
+	req := httptest.NewRequest("POST", fmt.Sprintf("/v1/boards/%s/articles/%s", boardID, filename), nil)
+	rr := httptest.NewRecorder()
+	delivery.forwardArticle(rr, req, boardID, filename)
+	expected := map[string]interface{}{
+		"error":             "no_required_parameter",
+		"error_description": "required parameter: email or board_id not found",
+	}
+	actual := make(map[string]interface{})
+	err = json.Unmarshal(rr.Body.Bytes(), &actual)
+	if err != nil {
+		t.Fatalf("got error: \"%s\" when parsing response body", err.Error())
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("expected %v but got %v", expected, actual)
+	}
+
+	// check parameters error
+	req = httptest.NewRequest("POST", fmt.Sprintf("/v1/boards/%s/articles/%s", boardID, filename), nil)
+	rr = httptest.NewRecorder()
+	req.Header.Add("Authorization", "bearer "+token)
+	delivery.forwardArticle(rr, req, boardID, filename)
+	if !reflect.DeepEqual(rr.Body.Bytes(), NewNoRequiredParameterError(req, "email or board_id")) {
+		t.Fatalf("expected %s but got %s", string(NewNoRequiredParameterError(req, "email or board_id")), rr.Body.String())
+	}
+
+	// check forward article to board
+	body := url.Values{}
+	body.Add("action", "forward_article")
+	body.Add("board_id", toBoardID)
+	req = httptest.NewRequest("POST",
+		fmt.Sprintf("/v1/boards/%s/articles/%s", boardID, filename),
+		strings.NewReader(body.Encode()))
+	rr = httptest.NewRecorder()
+	req.Header.Add("Authorization", "bearer "+token)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	usecase.token = token
+	permissionChecked := false
+	usecase.checkPermissionParameters = func(permission UseCase.Permission, permissionParameters map[string]string) {
+		permissionChecked = true
+		if permission != UseCase.PermissionForwardArticleToBoard {
+			t.Fatalf("expect permission check %s, but got %s", UseCase.PermissionForwardArticleToBoard, permission)
+		}
+		if pBoardID, ok := permissionParameters["board_id"]; !ok || pBoardID != boardID {
+			t.Fatalf("expect board id %s, but got %s", boardID, pBoardID)
+		}
+		if pToBoard, ok := permissionParameters["to_board"]; !ok || pToBoard != toBoardID {
+			t.Fatalf("expect to board id %s, but got %s", toBoardID, pToBoard)
+		}
+		if pArticle, ok := permissionParameters["article_id"]; !ok || pArticle != filename {
+			t.Fatalf("expect article id %s, but got %s", filename, pArticle)
+		}
+	}
+	isForwardToBoard := false
+	usecase.forwardArticleToBoard = func(pUserID, pBoardID, pFilename, pToBoard string) error {
+		isForwardToBoard = true
+		if pUserID != userData.UserID() {
+			t.Fatalf("expect user id %s, but got %s", userData.UserID(), pUserID)
+		}
+		if pBoardID != boardID {
+			t.Fatalf("expected board id %s, but got %s", boardID, pBoardID)
+		}
+		if pFilename != filename {
+			t.Fatalf("expect filename %s, but got %s", filename, pFilename)
+		}
+		if pToBoard != toBoardID {
+			t.Fatalf("expect to board id %s, but got %s", toBoardID, pToBoard)
+		}
+		return nil
+	}
+	delivery.forwardArticle(rr, req, boardID, filename)
+	if !permissionChecked {
+		t.Fatalf("Permission Not Checked")
+	}
+	if !isForwardToBoard {
+		t.Fatalf("forwardArticleToBoard function is not called")
+	}
+
+	// check forward article to email
+	body = url.Values{}
+	body.Add("action", "forward_article")
+	body.Add("email", email)
+	req = httptest.NewRequest("POST",
+		fmt.Sprintf("/v1/boards/%s/articles/%s", boardID, filename),
+		strings.NewReader(body.Encode()))
+	rr = httptest.NewRecorder()
+	req.Header.Add("Authorization", "bearer "+token)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	usecase.token = token
+	permissionChecked = false
+	usecase.checkPermissionParameters = func(permission UseCase.Permission, permissionParameters map[string]string) {
+		permissionChecked = true
+		if permission != UseCase.PermissionForwardArticleToEmail {
+			t.Fatalf("expect permission check %s, but got %s", UseCase.PermissionForwardArticleToBoard, permission)
+		}
+		if pBoardID, ok := permissionParameters["board_id"]; !ok || pBoardID != boardID {
+			t.Fatalf("expect board id %s, but got %s", boardID, pBoardID)
+		}
+		if pToEmail, ok := permissionParameters["to_email"]; !ok || pToEmail != email {
+			t.Fatalf("expect to board id %s, but got %s", toBoardID, pToEmail)
+		}
+		if pArticle, ok := permissionParameters["article_id"]; !ok || pArticle != filename {
+			t.Fatalf("expect article id %s, but got %s", filename, pArticle)
+		}
+	}
+	isForwardToEmail := false
+	usecase.forwardArticleToEmail = func(pUserID, pBoardID, pFilename, pToEmail string) error {
+		isForwardToEmail = true
+		if pUserID != userData.UserID() {
+			t.Fatalf("expect user id %s, but got %s", userData.UserID(), pUserID)
+		}
+		if pBoardID != boardID {
+			t.Fatalf("expected board id %s, but got %s", boardID, pBoardID)
+		}
+		if pFilename != filename {
+			t.Fatalf("expect filename %s, but got %s", filename, pFilename)
+		}
+		if pToEmail != email {
+			t.Fatalf("expect to board id %s, but got %s", email, pToEmail)
+		}
+		return nil
+	}
+	delivery.forwardArticle(rr, req, boardID, filename)
+	if !permissionChecked {
+		t.Fatalf("Permission Not Checked")
+	}
+	if !isForwardToEmail {
+		t.Fatalf("forwardArticleToBoard function is not called")
 	}
 }

--- a/internal/usecase/article.go
+++ b/internal/usecase/article.go
@@ -86,17 +86,6 @@ func (usecase *usecase) AppendComment(ctx context.Context, userID, boardID, file
 
 // ForwardArticleToBoard returns forwarding to board results
 func (usecase *usecase) ForwardArticleToBoard(ctx context.Context, userID, boardID, filename, boardName string) (repository.ForwardArticleToBoardRecord, error) {
-	token := usecase.CreateAccessTokenWithUsername(userID)
-
-	err := usecase.checkForwardArticlePermission(token,
-		map[string]string{
-			"board_id":   boardID,
-			"article_id": filename,
-		})
-	if err != nil {
-		return nil, fmt.Errorf("checkForwardArticlePermission error: %w", err)
-	}
-
 	forwardArticle, err := usecase.repo.ForwardArticleToBoard(ctx, userID, boardID, filename, boardName)
 	if err != nil {
 		return nil, fmt.Errorf("ForwardArticleToBoard error: %w", err)

--- a/internal/usecase/token.go
+++ b/internal/usecase/token.go
@@ -156,6 +156,7 @@ func (usecase *usecase) checkCreateArticlePermission(ctx context.Context, token 
 	return nil
 }
 
+// This function checks the user has permission that can forward the target article to another board.
 func (usecase *usecase) checkForwardArticleToBoardPermission(token string, userInfo map[string]string) error {
 	// boardID := userInfo["board_id"]
 	// toBoard := userInfo["to_board"]
@@ -173,11 +174,14 @@ func (usecase *usecase) checkForwardArticleToBoardPermission(token string, userI
 	return nil
 }
 
+// This function checks the user has permission that can forward the target article to the target email address.
+// Implementation should note that the target email is not a private email or an unresolved address.
 func (usecase *usecase) checkForwardArticleToEmailPermission(token string, userInfo map[string]string) error {
 	// boardID := userInfo["board_id"]
 	// toEmail := userInfo["to_email"]
 	// userID := userInfo["user_id"]
 
+	// TODO: 確認Email是可以轉發的
 	// TODO: 判斷是否有轉錄的權限
 	// TODO: 判斷在該版是否允許發文
 	// TODO: 判斷轉錄的版是否允許發文

--- a/internal/usecase/token.go
+++ b/internal/usecase/token.go
@@ -18,8 +18,8 @@ const (
 	PermissionReadFavorite            Permission = "READ_FAVORITE"
 	PermissionCreateArticle           Permission = "PUBLISH_POSTS"
 	PermissionAppendComment           Permission = "APPEND_COMMENT"
-	PermissionForwardArticle          Permission = "FORWARD_ARTICLE"
-	PermissionForwardAddArticle       Permission = "ADD_ARTICLE"
+	PermissionForwardArticleToBoard   Permission = "FORWARD_ARTICLE_TO_BOARD"
+	PermissionForwardArticleToEmail   Permission = "FORWARD_ARTICLE_TO_EMAIL"
 	PermissionUpdateDraft             Permission = "UPDATE_DRAFT"
 	PermissionDeleteDraft             Permission = "DELETE_DRAFT"
 )
@@ -102,8 +102,12 @@ func (usecase *usecase) CheckPermission(token string, permissionID []Permission,
 			}
 		case PermissionUpdateDraft:
 		case PermissionDeleteDraft:
-		case PermissionForwardArticle:
-			if err := usecase.checkForwardArticlePermission(token, userInfo); err != nil {
+		case PermissionForwardArticleToBoard:
+			if err := usecase.checkForwardArticleToBoardPermission(token, userInfo); err != nil {
+				return err
+			}
+		case PermissionForwardArticleToEmail:
+			if err := usecase.checkForwardArticleToEmailPermission(token, userInfo); err != nil {
 				return err
 			}
 		case PermissionCreateArticle:
@@ -111,7 +115,7 @@ func (usecase *usecase) CheckPermission(token string, permissionID []Permission,
 				return err
 			}
 		default:
-			return fmt.Errorf("undefined permission id:%s", permission)
+			return fmt.Errorf("undefined permission id: %s", permission)
 		}
 	}
 
@@ -152,8 +156,26 @@ func (usecase *usecase) checkCreateArticlePermission(ctx context.Context, token 
 	return nil
 }
 
-func (usecase *usecase) checkForwardArticlePermission(token string, userInfo map[string]string) error {
+func (usecase *usecase) checkForwardArticleToBoardPermission(token string, userInfo map[string]string) error {
 	// boardID := userInfo["board_id"]
+	// toBoard := userInfo["to_board"]
+	// userID := userInfo["user_id"]
+
+	// TODO: 判斷是否有轉錄的權限
+	// TODO: 判斷在該版是否允許發文
+	// TODO: 判斷轉錄的版是否允許發文
+	// TODO: 判斷在該版是否被水桶
+	// TODO: 判斷轉錄的次數上限
+	// TODO: 判斷轉錄的版跟現在的版是不同的
+	// TODO: 判斷冷卻時間
+	// TODO: 判斷 CAPTCHA 驗證是否通過
+
+	return nil
+}
+
+func (usecase *usecase) checkForwardArticleToEmailPermission(token string, userInfo map[string]string) error {
+	// boardID := userInfo["board_id"]
+	// toEmail := userInfo["to_email"]
 	// userID := userInfo["user_id"]
 
 	// TODO: 判斷是否有轉錄的權限

--- a/testing-script/C6-1-7.sh
+++ b/testing-script/C6-1-7.sh
@@ -13,5 +13,5 @@ echo "add success: $NEW_FILENAME"
 
 
 
-curl http://localhost:8081/v1/boards/test/articles/$NEW_FILENAME -d 'action=forward_article'  --data-urlencode 'board_id=test' 
+curl http://localhost:8081/v1/boards/test/articles/$NEW_FILENAME -d 'action=forward_article'  --data-urlencode 'board_id=test' -H "Authorization: bearer $ACCESS_TOKEN"
 curl  -s http://localhost:8081/v1/boards/test/articles -H "Authorization: bearer $ACCESS_TOKEN" | jq -r '[.data.items[] | select(.title == "[測試] test")][-1] | .filename'

--- a/testing-script/C6-1-8.sh
+++ b/testing-script/C6-1-8.sh
@@ -17,4 +17,4 @@ echo "add success: $NEW_FILENAME"
 
 
 
-curl http://localhost:8081/v1/boards/test/articles/$NEW_FILENAME -d 'action=forward_article'  --data-urlencode "email=$1"
+curl http://localhost:8081/v1/boards/test/articles/$NEW_FILENAME -H "Authorization: bearer $ACCESS_TOKEN" -d 'action=forward_article'  --data-urlencode "email=$1"


### PR DESCRIPTION


<!-- 原則上不接受沒有 Issue ID 的 PR。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決掉的 issue / Resolved Issues
- close #286 

## ⛏ 變更內容 / Details of Changes
<!-- 簡要陳列您的修改 -->
<!-- List down your changes concisely -->
* change parameter `board` to `board_id` ([文件](https://docs.google.com/document/d/18DsZOyrlr5BIl2kKxZH7P2QxFLG02xL2SO0PzVHVY3k/edit#heading=h.r3t24bsqupvy)裡面是寫 `board_id` 而非 `board`)
* add permission type `PermissionForwardArticleToBoard` and `PermissionForwardArticleToEmail`
* remove permission type `PermissionForwardArticle` and `PermissionForwardAddArticle`
* fix test file `C6-1-7.sh` and `C6-1-8.sh` in testing-script
* remove redundant test in function `usecase.ForwardArticleToBoard` (我看其他的函數都沒有檢查，只有這個有，所以我就統一都刪掉了)
* add error `NoPermissionForForwardArticleError` and `NoPermissionForForwardArticleToEmailError`