### PR TITLE
Fix is_header_modified typo

### DIFF
--- a/internal/delivery/http/route_append_comment.go
+++ b/internal/delivery/http/route_append_comment.go
@@ -103,12 +103,12 @@ func (delivery *Delivery) appendComment(w http.ResponseWriter, r *http.Request, 
 		"data": map[string]interface{}{
 			"raw": res.Text(),
 			"parsed": map[string]interface{}{
-				"is_header_modied": false,
-				"author_id":        userID,
-				"author_name":      userID,
-				"title":            nil,
-				"post_time":        res.Time().Format("2006-01-02 15:04:05"),
-				"board_name":       boardID, // todo: go-bbs articles 需實作新介面取得資訊
+				"is_header_modified": false,
+				"author_id":          userID,
+				"author_name":        userID,
+				"title":              nil,
+				"post_time":          res.Time().Format("2006-01-02 15:04:05"),
+				"board_name":         boardID, // todo: go-bbs articles 需實作新介面取得資訊
 				"text": map[string]string{
 					"text": text, // todo: // todo: go-bbs articles 需實作新介面取得資訊
 				},

--- a/internal/delivery/http/route_create_article.go
+++ b/internal/delivery/http/route_create_article.go
@@ -74,12 +74,12 @@ func (delivery *Delivery) publishPost(w http.ResponseWriter, r *http.Request, bo
 		"data": map[string]interface{}{
 			"raw": base64.StdEncoding.EncodeToString([]byte(raw)),
 			"parsed": map[string]interface{}{
-				"is_header_modied": false,
-				"author_id":        userID,
-				"board_name":       boardID, // todo: go-bbs articles 需實作新介面取得資訊
-				"author_name":      record.Owner(),
-				"title":            record.Title(),
-				"post_time":        record.Date(),
+				"is_header_modified": false,
+				"author_id":          userID,
+				"board_name":         boardID, // todo: go-bbs articles 需實作新介面取得資訊
+				"author_name":        record.Owner(),
+				"title":              record.Title(),
+				"post_time":          record.Date(),
 				"text": map[string]string{
 					"text": article, // todo: go-bbs articles 需實作新介面取得資訊
 				},

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -704,7 +704,7 @@ paths:
                       parsed:
                         type: object
                         properties:
-                          is_header_modied:
+                          is_header_modified:
                             type: string
                           author_id:
                             type: string
@@ -844,7 +844,7 @@ paths:
                       parsed:
                         type: object
                         properties:
-                          is_header_modify:
+                          is_header_modified:
                             type: string
                           author_id:
                             type: string


### PR DESCRIPTION
## Summary
- fix typographical error `is_header_modied` to `is_header_modified`
- correct leftover `is_header_modify` in swagger spec
- keep formatting consistent

## Testing
- `go test ./...` *(fails: unable to download go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683fdab79a748326bc5eb340a86d6046